### PR TITLE
3 deactivate account

### DIFF
--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -6,7 +6,7 @@ module Auth
     def destroy
       resource.update!(deactivated_at: DateTime.now) if resource.deactivated_at.blank?
       sign_out
-      set_flash_message! :noticed, :destroyed
+      set_flash_message! :notice, :destroyed
       respond_with_navigational(resource) { redirect_to after_sign_out_path_for(resource_name) }
     rescue ActiveRecord::RecordInvalid
       flash[:alert] = 'Your account cannot be deactivated.'

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Auth
+  class RegistrationsController < Devise::RegistrationsController
+    # The default destroy is changed to only deactivate the user, based on the official devise github
+    def destroy
+      resource.update(deactivated_at: DateTime.now) if resource.deactivated_at.present?
+      sign_out
+      set_flash_message! :noticed, :destroyed
+      respond_with_navigational(resource) { redirect_to after_sign_out_path_for(resource_name) }
+    end
+  end
+end

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -4,10 +4,13 @@ module Auth
   class RegistrationsController < Devise::RegistrationsController
     # The default destroy is changed to only deactivate the user, based on the official devise github
     def destroy
-      resource.update(deactivated_at: DateTime.now) if resource.deactivated_at.present?
+      resource.update!(deactivated_at: DateTime.now) if resource.deactivated_at.blank?
       sign_out
       set_flash_message! :noticed, :destroyed
       respond_with_navigational(resource) { redirect_to after_sign_out_path_for(resource_name) }
+    rescue ActiveRecord::RecordInvalid
+      flash[:alert] = 'Your account cannot be deactivated.'
+      redirect_to edit_user_registration_path
     end
   end
 end

--- a/app/controllers/deactivates_controller.rb
+++ b/app/controllers/deactivates_controller.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class DeactivatesController < ApplicationController
-
   def destroy
     @user = authorize User.find_by(id: params[:user_id]), :edit?
-    if !@user.admin?
-      @user.update(deactivated_at: DateTime.now)
-    else
+    if @user.admin?
       raise Pundit::NotAuthorizedError
+    else
+      @user.update(deactivated_at: DateTime.now)
     end
+
     redirect_to users_path
   end
 end

--- a/app/controllers/deactivates_controller.rb
+++ b/app/controllers/deactivates_controller.rb
@@ -2,7 +2,7 @@
 
 class DeactivatesController < ApplicationController
   def destroy
-    @user = authorize User.find_by(id: params[:user_id]), :destroy?
+    @user = authorize(User.find_by(id: params[:user_id]), policy_class: DeactivatePolicy)
     if @user.update(deactivated_at: DateTime.now)
       flash[:notice] = 'User deactivated successfully!'
     else

--- a/app/controllers/deactivates_controller.rb
+++ b/app/controllers/deactivates_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class DeactivatesController < ApplicationController
+
+  def destroy
+    @user = authorize User.find_by(id: params[:user_id]), :edit?
+    if !@user.admin?
+      @user.update(deactivated_at: DateTime.now)
+    else
+      raise Pundit::NotAuthorizedError
+    end
+    redirect_to users_path
+  end
+end

--- a/app/controllers/deactivates_controller.rb
+++ b/app/controllers/deactivates_controller.rb
@@ -2,11 +2,11 @@
 
 class DeactivatesController < ApplicationController
   def destroy
-    @user = authorize User.find_by(id: params[:user_id]), :edit?
-    if @user.admin?
-      raise Pundit::NotAuthorizedError
+    @user = authorize User.find_by(id: params[:user_id]), :destroy?
+    if @user.update(deactivated_at: DateTime.now)
+      flash[:notice] = 'User deactivated successfully!'
     else
-      @user.update(deactivated_at: DateTime.now)
+      flash[:alert] = 'This user cannot be deactivated.'
     end
 
     redirect_to users_path

--- a/app/controllers/deactivates_controller.rb
+++ b/app/controllers/deactivates_controller.rb
@@ -2,13 +2,20 @@
 
 class DeactivatesController < ApplicationController
   def destroy
-    @user = authorize(User.find_by(id: params[:user_id]), policy_class: DeactivatePolicy)
-    if @user.update(deactivated_at: DateTime.now)
-      flash[:notice] = 'User deactivated successfully!'
-    else
-      flash[:alert] = 'This user cannot be deactivated.'
-    end
+    @user = User.find_by(id: params[:user_id])
 
-    redirect_to users_path
+    if policy([:attributes, @user]).valid_deactivated_at?(DateTime.now)
+      skip_authorization
+
+      if @user.update(deactivated_at: DateTime.now)
+        flash[:notice] = 'User deactivated successfully!'
+      else
+        flash[:alert] = 'This user cannot be deactivated.'
+      end
+
+      redirect_to users_path
+    else
+      raise Pundit::NotAuthorizedError
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   validates :admin, inclusion: { in: [true, false] }
+
+  def active_for_authentication?
+    super && deactivated_at.blank?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,8 @@ class User < ApplicationRecord
   def active_for_authentication?
     super && deactivated_at.blank?
   end
+
+  def deactivated?
+    deactivated_at.present?
+  end
 end

--- a/app/policies/attributes/user_policy.rb
+++ b/app/policies/attributes/user_policy.rb
@@ -9,5 +9,13 @@ module Attributes
         user == record && record.admin?
       end
     end
+
+    def valid_deactivated_at?(next_value)
+      if next_value.present?
+        (admin? && !record.admin?) || user == record
+      else
+        false
+      end
+    end
   end
 end

--- a/app/policies/deactivate_policy.rb
+++ b/app/policies/deactivate_policy.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class DeactivatePolicy < ApplicationPolicy
-  def destroy?
-    (admin? && !record.admin?) || user == record
-  end
-end

--- a/app/policies/deactivate_policy.rb
+++ b/app/policies/deactivate_policy.rb
@@ -2,6 +2,6 @@
 
 class DeactivatePolicy < ApplicationPolicy
   def destroy?
-    admin? || user == record
+    (admin? && !record.admin?) || user == record
   end
 end

--- a/app/policies/deactivate_policy.rb
+++ b/app/policies/deactivate_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DeactivatePolicy < ApplicationPolicy
+  def destroy?
+    admin? || user == record
+  end
+end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -11,7 +11,8 @@
               <tr>
                 <th scope="col">#</th>
                 <th scope="col">Name</th>
-                <th scope="col">Add or Remove</th>
+                <th scope="col">Add or Remove as Admin</th>
+                <th scope="col">Deactivate</th>
               </tr>
             </thead>
             <tbody>
@@ -26,6 +27,18 @@
                       <%= link_to 'Add', user_admin_path(user), method: :post, class: 'btn btn-success' %>
                     <% else %>
                       <%= user.admin? ? 'Admin' : 'User' %>
+                    <% end %>
+                  </td>
+                  <td>
+                    <% if user.admin? %>
+                      <%= 'Admins can deactivate themselves' %>
+                    <% else %>
+                      <% if user.deactivated? %>
+                        <%= 'Deactivated' %>
+                      <% else %>
+                        <%= link_to 'Deactivate', user_deactivate_path(user),
+                                    method: :delete, class: 'btn btn-warning' %>
+                      <% end %>
                     <% end %>
                   </td>
                 </tr>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -31,10 +31,10 @@
                   </td>
                   <td>
                     <% if user.admin? %>
-                      <%= 'Admins can deactivate themselves' %>
+                      Admins can only be deactivate by themselves
                     <% else %>
                       <% if user.deactivated? %>
-                        <%= 'Deactivated' %>
+                        Deactivated
                       <% else %>
                         <%= link_to 'Deactivate', user_deactivate_path(user),
                                     method: :delete, class: 'btn btn-warning' %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -22,9 +22,9 @@
                   <td><%= user.first_name %> <%= user.last_name %></td>
                   <td class="py-1">
                     <% if policy([:attributes, user]).valid_admin?(false) %>
-                      <%= link_to 'Remove', user_admin_path(user), method: :delete, class: 'btn btn-danger' %>
+                      <%= link_to 'Remove As Admin', user_admin_path(user), method: :delete, class: 'btn btn-danger' %>
                     <% elsif policy([:attributes, user]).valid_admin?(true) %>
-                      <%= link_to 'Add', user_admin_path(user), method: :post, class: 'btn btn-success' %>
+                      <%= link_to 'Add As Admin', user_admin_path(user), method: :post, class: 'btn btn-success' %>
                     <% else %>
                       <%= user.admin? ? 'Admin' : 'User' %>
                     <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -30,14 +30,14 @@
                     <% end %>
                   </td>
                   <td>
-                    <% if user.admin? %>
-                      Admins can only be deactivate by themselves
+                    <% if user.deactivated? %>
+                      Deactivated
                     <% else %>
-                      <% if user.deactivated? %>
-                        Deactivated
-                      <% else %>
+                      <% if policy([:attributes, user]).valid_deactivated_at?(DateTime.now) %>
                         <%= link_to 'Deactivate', user_deactivate_path(user),
                                     method: :delete, class: 'btn btn-warning' %>
+                      <% else %>
+                        You can't deactivate this user!
                       <% end %>
                     <% end %>
                   </td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  devise_for :users, path: 'auth'
+  devise_for :users, path: 'auth', controllers: { registrations: 'auth/registrations' }
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root 'home#index'
   resources :projects do
@@ -14,5 +14,6 @@ Rails.application.routes.draw do
   end
   resources :users, only: [:new, :create, :edit, :update, :index] do
     resource :admin, only: [:create, :destroy]
+    resource :deactivate, only: [:destroy]
   end
 end

--- a/db/migrate/20240119103634_add_deactivated_to_users.rb
+++ b/db/migrate/20240119103634_add_deactivated_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDeactivatedToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :deactivated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_13_081423) do
+ActiveRecord::Schema.define(version: 2024_01_19_103634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 2023_10_13_081423) do
     t.string "first_name"
     t.string "last_name"
     t.boolean "admin", default: false, null: false
+    t.datetime "deactivated_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/requests/deactivates_spec.rb
+++ b/spec/requests/deactivates_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Deactivates' do
+  describe 'deactivate user' do
+    let(:user) { create(:user, admin: admin) }
+    let(:admin) { true }
+
+    let(:user_to_be_deactivated) { create(:user) }
+
+    before do
+      login_as user
+    end
+
+    it 'deactivates the user' do
+      expect { delete user_deactivate_path(user_to_be_deactivated) }
+        .to change { user_to_be_deactivated.reload.deactivated_at }
+        .from(nil)
+        .to(be_present)
+    end
+
+    context 'when the current user is not admin' do
+      let(:admin) { false }
+
+      it 'does not deactivate the user' do
+        expect { delete user_deactivate_path(user_to_be_deactivated) }
+          .not_to change { user_to_be_deactivated.reload.deactivated_at }
+          .from(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #3 

Users can deactivate their own accounts from their password page.
Admin users can deactivate basic users from the admin page.
Default user destroy action is changed to just deativate, not complete destroy.