### PR TITLE
fix bundler deprecation warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,4 +317,4 @@ RUBY VERSION
    ruby 3.2.3p157
 
 BUNDLED WITH
-   2.2.22
+   2.5.10


### PR DESCRIPTION
This should fix the following error:

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
```

See for details: https://github.com/rubygems/rubygems/issues/5234