### PR TITLE
213 send email with button

### DIFF
--- a/app/mailers/form_mailer.rb
+++ b/app/mailers/form_mailer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class FormMailer < ApplicationMailer
+  def send_form
+    @user = params[:user]
+    @form = params[:form]
+
+    mail(to: @user.email, subject: 'AppMaintainers Feedback')
+  end
+end

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -5,6 +5,10 @@ class FormPolicy < ApplicationPolicy
     admin?
   end
 
+  def send_form?
+    admin?
+  end
+
   class Scope < Scope
     def resolve
       if admin?

--- a/app/views/form_mailer/send_form.html.erb
+++ b/app/views/form_mailer/send_form.html.erb
@@ -1,0 +1,4 @@
+<p>Dear <%= @user.first_name %>,</p>
+<p>Please provide us with your feedback regarding <%= link_to 'our mutual project', @form.share_link %>.</p>
+<p>We thank you for your feedback in advance,</p>
+<p>the AppMaintainers team</p>

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -11,6 +11,7 @@
                   <tr>
                     <th>Title</th>
                     <th>Description</th>
+                    <th>Send Form</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -18,6 +19,12 @@
                     <tr>
                       <td><%= link_to form.title, feedbacks_path(feedback: { form_id: form.id }) %></td>
                       <td><%= form.description %></td>
+                      <td>
+                        <%= link_to 'Send', send_form_form_path(form),
+                                    method: :post,
+                                    data: { confirm: 'Are you sure you want to send this form via email to all non-admin maintainers?' },
+                                    class: 'btn btn-primary' %>
+                      </td>
                     </tr>
                   <% end %>
                 </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,11 @@ Rails.application.routes.draw do
       resource :admin, only: [:create, :destroy]
       resource :deactivate, only: [:destroy]
     end
-    resources :forms, only: [:index]
+    resources :forms, only: [:index] do
+      member do
+        post :send_form
+      end
+    end
     resources :feedbacks, only: [:index]
   end
 end

--- a/spec/policies/admin/form_policy_spec.rb
+++ b/spec/policies/admin/form_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe FormPolicy do
   describe 'how to handle concrete objects' do
     let(:object_to_check) { Form }
 
-    it { is_expected.to permit_actions [:index] }
+    it { is_expected.to permit_actions [:index, :send_form] }
     it { is_expected.to forbid_actions [:show, :destroy, :new, :create, :edit, :update] }
   end
 end

--- a/spec/policies/user/form_policy_spec.rb
+++ b/spec/policies/user/form_policy_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe FormPolicy do
     let(:object_to_check) { Form }
 
     it { is_expected.to permit_actions [] }
-    it { is_expected.to forbid_actions [:show, :destroy, :new, :create, :edit, :update, :index] }
+    it { is_expected.to forbid_actions [:show, :destroy, :new, :create, :edit, :update, :index, :send_form] }
   end
 end

--- a/spec/requests/form_spec.rb
+++ b/spec/requests/form_spec.rb
@@ -37,4 +37,25 @@ RSpec.describe 'Forms' do
       end
     end
   end
+
+  describe 'Send Form' do
+    let(:user) { create(:user, :admin) }
+    let(:form) { create(:form) }
+
+    before do
+      login_as user
+      form.project.maintainers << create(:user)
+      form.project.maintainers << create(:user, :admin)
+    end
+
+    it 'redirects to forms index' do
+      post send_form_form_path(form)
+
+      expect(response).to redirect_to(forms_path)
+    end
+
+    it 'sends emails to non admin users' do
+      expect { post send_form_form_path(form) }.to change { ActionMailer::Base.deliveries.size }.by(1)
+    end
+  end
 end


### PR DESCRIPTION
closes #213 

- `/forms` oldalra lett bevezetve a gomb.
- A Form Project-hez tartozik (one-to-many), ezért form-onként egy-egy gomb jelenik meg az oldalon.
- Az issue nem specifikálta hogy melyik user-ek kapnak email-t. Form-onként mindig az adott Project nem admin maintainer-einek lesz kiküldve az email.